### PR TITLE
fix: 삭제된 prod.Dockerfile 이 아닌 dev.Dockerfile 로 빌드하도록 Jenkinsfile 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
             }
             steps {
                 script {
-                    def dockerfile = 'prod.Dockerfile'
+                    def dockerfile = 'dev.Dockerfile'
                     def image = docker.build("${env.DOCKER_IMAGE}", "-f ./dockerfiles/${dockerfile} .")
                     env.DOCKER_IMAGE_ID = image.id
                 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

- `fork dev` -> `dev`

### 변경 사항

- 삭제된 prod.Dockerfile 이 아닌 dev.Dockerfile 로 빌드하도록 Jenkinsfile 수정
