### PR TITLE
운영서버에 빌드 결과물 배포하는 workflow 파일 추가

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,73 @@
+name: backend-deploy-production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  set-env-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      ecr-repository: ${{ steps.set-envs.outputs.ecr-repository }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+      - name: Set Production Docker Repository Name
+        id: set-envs
+        if: github.ref_name == 'main'
+        run: |
+          ECR_REPOSITORY=$(aws ssm get-parameter --name /prod/front/image-name --query 'Parameter.Value' --output text)
+          echo "ecr-repository=$ECR_REPOSITORY" >> "$GITHUB_OUTPUT"
+
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    needs: set-env-vars
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ needs.set-env-vars.outputs.ecr-repository }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          aws ssm get-parameter --name /prod/front --query 'Parameter.Value' --output text > .env
+          docker buildx build --platform=linux/amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f ./dockerfiles/prod.Dockerfile . 
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: docker-build-and-push
+    if: github.ref_name == 'main'
+    steps:
+      - name: Deploy to Production Environment
+        env:
+          ECR_REPOSITORY: ${{ needs.set-env-vars.outputs.ecr-repository }}
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.PROD_TARGET_HOST }}
+          username: ${{ secrets.PROD_SSH_USERNAME }}
+          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.PROD_SSH_PORT }}
+          script: |
+            sh awslogin.sh
+            cd application
+            docker compose pull && docker compose up -d


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

- `devops` -> `main`

### 변경 사항

- 운영서버에 빌드 결과물 배포하는 workflow 파일 추가

### 테스트 결과

- [fork 한 프로젝트](https://github.com/kmss6905/it-that-cat/actions/runs/11304848676)에서 테스트한 파일 그대로 사용했습니다.
